### PR TITLE
Do not call cx_hash with CX_NO_REINIT

### DIFF
--- a/src/monero_crypto.c
+++ b/src/monero_crypto.c
@@ -167,7 +167,7 @@ int monero_hash(unsigned int algo, cx_hash_t * hasher, unsigned char* buf, unsig
     } else {
         cx_keccak_init((cx_sha3_t *)hasher, 256);
     }
-    return cx_hash(hasher, CX_LAST|CX_NO_REINIT, buf, len, out, 32);
+    return cx_hash(hasher, CX_LAST, buf, len, out, 32);
 }
 
 /* ----------------------------------------------------------------------- */


### PR DESCRIPTION
Currently `monero_hash_final()` calls `cx_hash(CX_LAST)` and `monero_hash()` calls `cx_hash(CX_LAST|CX_NO_REINIT)`. This is quite confusing.

As option `CX_NO_REINIT` is not used by `cx_hash` anyway, drop it.