### PR TITLE
Fix transition check for INS_PREFIX_HASH

### DIFF
--- a/src/monero_dispatch.c
+++ b/src/monero_dispatch.c
@@ -330,7 +330,7 @@ int monero_dispatch() {
       }
     } else if  (G_monero_vstate.tx_state_p1 == 2) {
       if ((G_monero_vstate.io_p1 != 2)||
-          (G_monero_vstate.io_p1-1 != G_monero_vstate.tx_state_p2)) {
+          (G_monero_vstate.io_p2-1 != G_monero_vstate.tx_state_p2)) {
           THROW(SW_SUBCOMMAND_NOT_ALLOWED);
       }
     } else {


### PR DESCRIPTION
Protocol v3 introduced `INS_PREFIX_HASH` in order to verify the timelock on devices. This works by sending the following sequence of APDU:

- INS=INS_PREFIX_HASH, P1=1, content={varint version, varint timelock}
- INS=INS_PREFIX_HASH, P1=2, P2=1, content=1st chunk of data
- INS=INS_PREFIX_HASH, P1=2, P2=2, content=2nd chunk of data
- INS=INS_PREFIX_HASH, P1=2, P2=3, content=3rd chunk of data
- ...

(cf. function `device_ledger::get_transaction_prefix_hash()` from https://github.com/monero-project/monero/blob/77a008f71454ce4dd4bce033bc0319a49e2cec51/src/device/device_ledger.cpp#L1418)

Currently, the first 2 chunks of data are accepted but not the 3rd one: the device then returns `SW=0x6981` = `SW_SUBCOMMAND_NOT_ALLOWED`.

This is because the dispatcher incorrectly compares P1-1 with the last
P2, instead of P2-1. Fix this.