### PR TITLE
Forbid transition from INS_BLIND to INS_VALIDATE(P1=2) directly

### DIFF
--- a/src/monero_dispatch.c
+++ b/src/monero_dispatch.c
@@ -418,6 +418,10 @@ int monero_dispatch() {
       G_monero_vstate.tx_state_ins = INS_VALIDATE;
       G_monero_vstate.tx_state_p1 = 1;
       G_monero_vstate.tx_state_p2 = 0;
+      if ((G_monero_vstate.io_p1 != 1) ||
+          (G_monero_vstate.io_p2 != 1)) {
+        THROW(SW_SUBCOMMAND_NOT_ALLOWED);
+      }
     }
     //check new state is allowed
     if (G_monero_vstate.tx_state_p1 == G_monero_vstate.io_p1) {


### PR DESCRIPTION
When signing a Monero transaction, the state machine of the APDU is expected to behave like this:

- ...
- INS=INS_BLIND (possibly repeated)
- INS=INS_VALIDATE, P1=1, P2=1
  => call monero_apdu_mlsag_prehash_init() that updates some hashes and
  asks the user to validate the fee
- INS=INS_VALIDATE, P1=1, P2=2
- INS=INS_VALIDATE, P1=1, P2=3
- ...
- INS=INS_VALIDATE, P1=2, P2=1
- INS=INS_VALIDATE, P1=2, P2=2
- ...

Because of the way the transition from `INS_BLIND` is verified, it is currently possible to skip `INS=INS_VALIDATE, P1=1` by sending `INS=INS_VALIDATE, P1=2, P2=1` direcly. This makes the transaction signing fail later, because some hash states did not get reset properly, so this would not have any impact from a security perspective. Nevertheless, removing this unexpected transition makes working on the state machine easier.