### PR TITLE
Security fix and support of monero client 0.16.0.0

### DIFF
--- a/src/monero_dispatch.c
+++ b/src/monero_dispatch.c
@@ -47,7 +47,6 @@ int check_potocol()  {
   /* the first command enforce the protocol version until application quits */
   switch(G_monero_vstate.io_protocol_version) {
    case 0x00: /* the first one: PCSC epoch */
-   case 0x02: /* protocol V2 */
    case 0x03: /* protocol V3 */
     if (G_monero_vstate.protocol == 0xff) {
       G_monero_vstate.protocol = G_monero_vstate.io_protocol_version;
@@ -305,9 +304,6 @@ int monero_dispatch() {
   /* --- PREFIX HASH  --- */
   case INS_PREFIX_HASH:
     //1. state machine check
-    if (G_monero_vstate.protocol < 3) {
-      THROW(SW_COMMAND_NOT_ALLOWED);
-    }
     if ((G_monero_vstate.tx_state_ins != INS_GEN_TXOUT_KEYS) &&
       (G_monero_vstate.tx_state_ins != INS_PREFIX_HASH)) {
         THROW(SW_COMMAND_NOT_ALLOWED);
@@ -351,12 +347,6 @@ int monero_dispatch() {
     /*--- COMMITMENT MASK --- */
   case INS_GEN_COMMITMENT_MASK:
     //1. state machine check
-    if (G_monero_vstate.protocol == 2) {
-      if ((G_monero_vstate.tx_state_ins != INS_GEN_TXOUT_KEYS) && 
-          (G_monero_vstate.tx_state_ins != INS_GEN_COMMITMENT_MASK)) {
-        THROW(SW_COMMAND_NOT_ALLOWED);
-      }
-    }
     if (G_monero_vstate.protocol == 3) {
       if ((G_monero_vstate.tx_state_ins != INS_PREFIX_HASH) && 
           (G_monero_vstate.tx_state_ins != INS_GEN_COMMITMENT_MASK)) {
@@ -377,12 +367,6 @@ int monero_dispatch() {
   case INS_BLIND:
     //1. state machine check
     if (G_monero_vstate.tx_sig_mode == TRANSACTION_CREATE_FAKE) {
-      if (G_monero_vstate.protocol == 2) {
-        if ((G_monero_vstate.tx_state_ins != INS_GEN_TXOUT_KEYS) &&
-            (G_monero_vstate.tx_state_ins != INS_BLIND)) {
-          THROW(SW_COMMAND_NOT_ALLOWED);
-        }
-      }
       if (G_monero_vstate.protocol == 3) {
        if ((G_monero_vstate.tx_state_ins != INS_PREFIX_HASH) &&
             (G_monero_vstate.tx_state_ins != INS_BLIND)) {

--- a/src/monero_init.c
+++ b/src/monero_init.c
@@ -175,7 +175,7 @@ void monero_install(unsigned char netId) {
 /* ----------------------------------------------------------------------- */
 #define MONERO_SUPPORTED_CLIENT_SIZE 1
 const char * const monero_supported_client[MONERO_SUPPORTED_CLIENT_SIZE] = {
-  "0.15.0.",
+  "0.16.0.",
 };
 
 int monero_apdu_reset() {


### PR DESCRIPTION
- Support of released monero client [0.16.0.0](https://web.getmonero.org/2020/05/23/monero-0.16-released.html).

- Security fix of [Monero funds lock-up](https://donjon.ledger.com/lsb/009/).

    - Remove compatibility with protocol `v2`
    - Force supported monero client `>=0.16.0.0`