### PR TITLE
seed conversion tool: replace relative import to support pyinstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ debug/
 dep/
 obj/
 
-
 # Editors
 .vscode/
 .idea/
@@ -18,3 +17,9 @@ __pycache__/
 *.egg-info/
 .eggs/
 .python-version
+
+# Pyinstaller
+build/
+dist/
+*.manifest
+*.spec

--- a/tools/python/README.md
+++ b/tools/python/README.md
@@ -65,11 +65,11 @@ On Mac/Linux
 
 In tools/python/ directory run the command:
 
-     PYTHONPATH=`pwd`/src  python3 -m ledger.monero.seedconv.py offline
+     PYTHONPATH=`pwd`/src python3 src/ledger/monero/seedconv.py offline
 
 Example:
 
-    $ PYTHONPATH="$(pwd)/src" python3 -m ledger.monero.seedconv offline
+    $ PYTHONPATH="$(pwd)/src" python3 src/ledger/monero/seedconv.py offline
 
         =============================================================
         Monero Seed Converter v0.9. Copyright (c) Ledger SAS 20018.
@@ -113,11 +113,11 @@ Example:
 
 In tools/python/ directory run the command:
 
-     PYTHONPATH=`pwd`/src  python3 -m ledger.monero.seedconv.py online
+     PYTHONPATH=`pwd`/src python3 src/ledger/monero/seedconv.py online
 
 Example:
 
-        $ PYTHONPATH=`pwd`/src  python3 -m ledger.monero.seedconv.py online
+        $ PYTHONPATH=`pwd`/src python3 src/ledger/monero/seedconv.py online
 
         =============================================================
         Monero Seed Converter v0.9. Copyright (c) Ledger SAS 20018.

--- a/tools/python/src/ledger/monero/seedconv.py
+++ b/tools/python/src/ledger/monero/seedconv.py
@@ -25,7 +25,7 @@ from Cryptodome.Hash import keccak
 
 
 
-from .dictionaries.languages import monero_langs
+from ledger.monero.dictionaries.languages import monero_langs
 
 
 # =========================================================================================


### PR DESCRIPTION
pyinstaller can be used to generate a single executable file which can
be run in an offline environment. However, it's unclear if it supports
running with `python -m` (module mode).