### PR TITLE
fix: validate change outputs after amount unblinding

### DIFF
--- a/src/monero_key.c
+++ b/src/monero_key.c
@@ -872,13 +872,11 @@ int monero_apu_generate_txout_keys(/*size_t tx_version, crypto::secret_key tx_se
     }
     use_view_tags = monero_io_fetch_u8();
 
-    // reject spoofed change address before any state is mutated
-    if (is_change && (G_monero_vstate.tx_sig_mode == TRANSACTION_CREATE_REAL)) {
-        err = monero_check_change_address(Aout, Bout);
-        if (err) {
-            goto end;
-        }
-    }
+    /*
+     * Change address check is done in INS_VALIDATE, after amount unblinding.
+     * Monero sweep_all/sweep_single transactions commonly keep two outputs by
+     * adding a dummy amount=0 change output, whose address is not wallet-owned.
+     */
 
     // update outkeys hash control
     if (G_monero_vstate.tx_sig_mode == TRANSACTION_CREATE_REAL) {

--- a/src/monero_monero.c
+++ b/src/monero_monero.c
@@ -120,6 +120,7 @@ static void encode_block(const unsigned char* block, unsigned int size, char* re
 int monero_base58_public_key(char* str_b58, unsigned char* view, unsigned char* spend,
                              unsigned char is_subbadress, unsigned char* paymanetID) {
     unsigned char data[72 + 8];
+    unsigned char hash[32];
     unsigned int offset;
     unsigned int prefix;
     int error = 0;
@@ -170,11 +171,11 @@ int monero_base58_public_key(char* str_b58, unsigned char* view, unsigned char* 
         memcpy(data + offset, paymanetID, 8);
         offset += 8;
     }
-    error = monero_keccak_F(data, offset, G_monero_vstate.mlsagH);
+    error = monero_keccak_F(data, offset, hash);
     if (error) {
-        return error;
+        goto end;
     }
-    memcpy(data + offset, G_monero_vstate.mlsagH, 4);
+    memcpy(data + offset, hash, 4);
     offset += 4;
 
     unsigned int full_block_count = (offset) / FULL_BLOCK_SIZE;
@@ -195,5 +196,7 @@ int monero_base58_public_key(char* str_b58, unsigned char* view, unsigned char* 
         str_b58[ADDR_LEN] = '\0';
     }
 
-    return 0;
+end:
+    explicit_bzero(hash, sizeof(hash));
+    return error;
 }

--- a/src/monero_prehash.c
+++ b/src/monero_prehash.c
@@ -99,9 +99,14 @@ int monero_apdu_mlsag_prehash_update() {
     unsigned char *Bout;
     unsigned char is_change;
     unsigned char AKout[KEY_SIZE];
+    unsigned char AKout_raw[KEY_SIZE];
     unsigned char C[32];
     unsigned char v[32];
+    unsigned char v_raw[32];
     unsigned char k[32];
+    unsigned char k_raw[32];
+    uint64_t amount;
+    unsigned int i;
 
 #define aH AKout
     unsigned char kG[32];
@@ -125,69 +130,38 @@ int monero_apdu_mlsag_prehash_update() {
     monero_io_fetch(C, 32);
     monero_io_fetch(k, 32);
     monero_io_fetch(v, 32);
+    memcpy(AKout_raw, AKout, KEY_SIZE);
+    memcpy(k_raw, k, 32);
+    memcpy(v_raw, v, 32);
 
     monero_io_discard(0);
 
-    // update MLSAG prehash
-    if ((G_monero_vstate.options & 0x03) == 0x02) {
-        err = monero_keccak_update_H(v, 8);
-        if (err) {
-            goto end;
-        }
-
-    } else {
-        err = monero_keccak_update_H(k, 32);
-        if (err) {
-            goto end;
-        }
-
-        err = monero_keccak_update_H(v, 32);
-        if (err) {
-            goto end;
-        }
-    }
-
     if (G_monero_vstate.tx_sig_mode == TRANSACTION_CREATE_REAL) {
-        // reject spoofed change address before any state is mutated
-        if (is_change) {
-            err = monero_check_change_address(Aout, Bout);
-            if (err) {
-                goto end;
-            }
-        }
-        if (is_change == 0) {
-            // encode dest adress
-            err = monero_base58_public_key(&G_monero_vstate.ux_address[0], Aout, Bout,
-                                           is_subaddress, NULL);
-            if (err) {
-                goto end;
-            }
-        }
-        // update destination hash control
-        if (G_monero_vstate.io_protocol_version >= 2) {
-            err = monero_sha256_outkeys_update(Aout, KEY_SIZE);
-            if (err) {
-                goto end;
-            }
-            err = monero_sha256_outkeys_update(Bout, KEY_SIZE);
-            if (err) {
-                goto end;
-            }
-            err = monero_sha256_outkeys_update(&is_change, 1);
-            if (err) {
-                goto end;
-            }
-            err = monero_sha256_outkeys_update(AKout, KEY_SIZE);
-            if (err) {
-                goto end;
-            }
-        }
-
         // check C = aH+kG
         err = monero_unblind(v, k, AKout, G_monero_vstate.options & 0x03, sizeof(v), sizeof(k),
                              sizeof(AKout));
         if (err) {
             goto end;
+        }
+
+        // short amounts must be canonical before being displayed as uint64
+        if ((G_monero_vstate.options & 0x03) == 0x02) {
+            for (i = 8; i < 32; i++) {
+                if (v[i] != 0) {
+                    err = SW_SECURITY_AMOUNT_CHAIN_CONTROL;
+                    goto end;
+                }
+            }
+        }
+
+        amount = monero_bamount2uint64(v, sizeof(v));
+
+        // sweep_all/sweep_single may include a dummy amount=0 change output
+        if (is_change && !cx_math_is_zero(v, 32)) {
+            err = monero_check_change_address(Aout, Bout);
+            if (err) {
+                goto end;
+            }
         }
 
         err = monero_ecmul_G(kG, k, sizeof(kG), sizeof(k));
@@ -214,6 +188,56 @@ int monero_apdu_mlsag_prehash_update() {
             goto end;
 #endif
         }
+        if (is_change == 0) {
+            // encode dest adress
+            err = monero_base58_public_key(&G_monero_vstate.ux_address[0], Aout, Bout,
+                                           is_subaddress, NULL);
+            if (err) {
+                goto end;
+            }
+        }
+    }
+
+    // update MLSAG prehash
+    if ((G_monero_vstate.options & 0x03) == 0x02) {
+        err = monero_keccak_update_H(v_raw, 8);
+        if (err) {
+            goto end;
+        }
+
+    } else {
+        err = monero_keccak_update_H(k_raw, 32);
+        if (err) {
+            goto end;
+        }
+
+        err = monero_keccak_update_H(v_raw, 32);
+        if (err) {
+            goto end;
+        }
+    }
+
+    if (G_monero_vstate.tx_sig_mode == TRANSACTION_CREATE_REAL) {
+        // update destination hash control
+        if (G_monero_vstate.io_protocol_version >= 2) {
+            err = monero_sha256_outkeys_update(Aout, KEY_SIZE);
+            if (err) {
+                goto end;
+            }
+            err = monero_sha256_outkeys_update(Bout, KEY_SIZE);
+            if (err) {
+                goto end;
+            }
+            err = monero_sha256_outkeys_update(&is_change, 1);
+            if (err) {
+                goto end;
+            }
+            err = monero_sha256_outkeys_update(AKout_raw, KEY_SIZE);
+            if (err) {
+                goto end;
+            }
+        }
+
         // update commitment hash control
         err = monero_sha256_commitment_update(C, 32);
         if (err) {
@@ -241,8 +265,6 @@ int monero_apdu_mlsag_prehash_update() {
         }
 
         // ask user
-        uint64_t amount;
-        amount = monero_bamount2uint64(v, sizeof(v));
         /* Rejecting signature for a non-change output with amount equal to 0.
          * Otherwise showing review sequence.
          */
@@ -275,8 +297,11 @@ int monero_apdu_mlsag_prehash_update() {
 
 end:
     explicit_bzero(AKout, sizeof(AKout));
+    explicit_bzero(AKout_raw, sizeof(AKout_raw));
     explicit_bzero(v, sizeof(v));
+    explicit_bzero(v_raw, sizeof(v_raw));
     explicit_bzero(k, sizeof(k));
+    explicit_bzero(k_raw, sizeof(k_raw));
     return err;
 
 #undef aH

--- a/tests/test_sig_real_no_change.py
+++ b/tests/test_sig_real_no_change.py
@@ -1,0 +1,219 @@
+"""Single-output Monero transaction test."""
+
+import pytest
+
+from ragger.backend.interface import BackendInterface
+from ragger.navigator import Navigator, NavInsID
+
+from monero_client.monero_cmd import MoneroCmd
+from monero_client.monero_crypto_cmd import MoneroCryptoCmd, PROTOCOL_VERSION
+from monero_client.monero_types import InsType, Keys, SigType, Type
+from monero_client.crypto.hmac import hmac_sha256
+from monero_client.utils.utils import get_nano_review_instructions
+
+
+INPUT_AMOUNT = 1_000_000_000_000
+FEE = 30_660_000
+OUTPUT_AMOUNT = INPUT_AMOUNT - FEE
+
+
+def _validate_prehash_update_no_compare(monero: MoneroCmd,
+                                         backend: BackendInterface,
+                                         navigator: Navigator,
+                                         index: int,
+                                         is_short: bool,
+                                         is_change_addr: bool,
+                                         is_subaddress: bool,
+                                         dst_pub_view_key: bytes,
+                                         dst_pub_spend_key: bytes,
+                                         _ak_amount: bytes,
+                                         commitment: bytes,
+                                         blinded_mask: bytes,
+                                         blinded_amount: bytes,
+                                         is_last: bool,
+                                         swipe_count: int) -> None:
+    device = backend.device
+    payload = b"".join((
+        b"\x01" if is_subaddress else b"\x00",
+        b"\x01" if is_change_addr else b"\x00",
+        dst_pub_view_key,
+        dst_pub_spend_key,
+        _ak_amount,
+        hmac_sha256(_ak_amount, MoneroCryptoCmd.HMAC_KEY, Type.AMOUNT_KEY),
+        commitment,
+        blinded_mask,
+        blinded_amount,
+    ))
+
+    instructions = None
+    if device.is_nano:
+        instructions = get_nano_review_instructions(1 if is_last else 3)
+    elif is_last:
+        instructions = [NavInsID.SWIPE_CENTER_TO_LEFT] * swipe_count + [
+            NavInsID.USE_CASE_REVIEW_TAP,
+            NavInsID.USE_CASE_REVIEW_CONFIRM,
+        ]
+
+    backend.wait_for_text_on_screen("Processing")
+    with monero.transport.send_async(
+        cla=PROTOCOL_VERSION,
+        ins=InsType.INS_VALIDATE,
+        p1=2,
+        p2=index,
+        option=(0 if is_last else 0x80) | (0x02 if is_short else 0),
+        payload=payload,
+    ):
+        if instructions is not None:
+            navigator.navigate(
+                instructions,
+                screen_change_after_last_instruction=False,
+                timeout=10000,
+            )
+
+    sw, response = monero.transport.async_response()
+    assert sw == 0x9000, f"Expected SW_OK, got {hex(sw)}"
+    assert len(response) == 0
+
+
+@pytest.mark.incremental
+class TestSignatureRealNoChange:
+    """Monero transaction test with a single non-change output."""
+
+    @staticmethod
+    @pytest.fixture(autouse=True, scope="class")
+    def state():
+        receiver = Keys(
+            public_view_key=bytes.fromhex("2e49ad29a1bfd98ab05c88713463d55212"
+                                          "0906b1be380211745695134e183ed0"),
+            public_spend_key=bytes.fromhex("392c4432e5a15aea227e6579a8da7d9f4"
+                                           "6fb78565e18e7f0b278f3f1a1468696"),
+            secret_view_key=bytes.fromhex("57fd02a94c7486722b1f9798dc0fb931d5"
+                                          "477a605a6fd6593573b438c02a890f"),
+            secret_spend_key=None,
+            addr="53zomVuwRkDgAQDY6qKUP6TeBy5JqXSJzhG4i7447yMXS7wdt4hKh6gQCTT"
+                 "a9FiYNpEjBoHZ9iTww3vL96P1hcmTQXvpFAo",
+        )
+
+        return {
+            "receiver_number": 1,
+            "receiver": [receiver],
+            "is_change_addr": [False],
+            "is_subaddress": [False],
+            "amount": [OUTPUT_AMOUNT],
+            "tx_pub_key": None,
+            "_tx_priv_key": None,
+            "_ak_amount": [[]],
+            "blinded_amount": [[]],
+            "blinded_mask": [[]],
+            "y": [[]],
+        }
+
+    @staticmethod
+    def test_set_sig_no_change(monero: MoneroCmd):
+        monero.reset_and_get_version(monero_client_version=b"0.18")
+        assert monero.set_signature_mode(sig_type=SigType.REAL) == SigType.REAL
+
+    @staticmethod
+    def test_open_tx_no_change(monero: MoneroCmd, state):
+        tx_pub_key, _tx_priv_key, fake_view_key, fake_spend_key = monero.open_tx()
+
+        assert fake_view_key == b"\x00" * 32
+        assert fake_spend_key == b"\xff" * 32
+
+        state["tx_pub_key"] = tx_pub_key
+        state["_tx_priv_key"] = _tx_priv_key
+
+    @staticmethod
+    def test_gen_txout_keys_no_change(monero: MoneroCmd, state):
+        _ak_amount, _ = monero.gen_txout_keys(
+            _tx_priv_key=state["_tx_priv_key"],
+            tx_pub_key=state["tx_pub_key"],
+            dst_pub_view_key=state["receiver"][0].public_view_key,
+            dst_pub_spend_key=state["receiver"][0].public_spend_key,
+            output_index=0,
+            is_change_addr=False,
+            is_subaddress=False,
+        )
+
+        state["_ak_amount"][0].append(_ak_amount)
+
+    @staticmethod
+    def test_prefix_hash_no_change(monero: MoneroCmd, navigator: Navigator,
+                                   device, test_name: str):
+        monero.prefix_hash_init(test_name, device, navigator=navigator,
+                                version=0, timelock=0)
+        monero.prefix_hash_update(index=1, payload=b"", is_last=True)
+
+    @staticmethod
+    def test_gen_commitment_mask_no_change(monero: MoneroCmd, state):
+        state["y"][0].append(monero.gen_commitment_mask(state["_ak_amount"][0][0]))
+
+    @staticmethod
+    def test_blind_no_change(monero: MoneroCmd, state):
+        assert OUTPUT_AMOUNT + FEE == INPUT_AMOUNT
+
+        blinded_mask, blinded_amount = monero.blind(
+            _ak_amount=state["_ak_amount"][0][0],
+            mask=state["y"][0][0],
+            amount=state["amount"][0],
+            is_short=True,
+        )
+
+        mask, amount = monero.unblind(
+            _ak_amount=state["_ak_amount"][0][0],
+            blinded_mask=blinded_mask,
+            blinded_amount=blinded_amount,
+            is_short=True,
+        )
+
+        assert state["y"][0][0] == mask
+        assert state["amount"][0] == int.from_bytes(amount, byteorder="little")
+
+        state["blinded_mask"][0].append(blinded_mask)
+        state["blinded_amount"][0].append(blinded_amount)
+
+    @staticmethod
+    def test_validate_no_change(monero: MoneroCmd,
+                                backend: BackendInterface,
+                                navigator: Navigator,
+                                test_name,
+                                state):
+        device = backend.device
+
+        monero.validate_prehash_init(test_name, device, navigator, 1, 0, FEE)
+
+        _validate_prehash_update_no_compare(
+            monero,
+            backend,
+            navigator,
+            index=1,
+            is_short=True,
+            is_change_addr=False,
+            is_subaddress=False,
+            dst_pub_view_key=state["receiver"][0].public_view_key,
+            dst_pub_spend_key=state["receiver"][0].public_spend_key,
+            _ak_amount=state["_ak_amount"][0][0],
+            commitment=bytes(32),
+            blinded_amount=state["blinded_amount"][0][0],
+            blinded_mask=state["blinded_mask"][0][0],
+            is_last=True,
+            swipe_count=2,
+        )
+
+        monero.validate_prehash_finalize(
+            index=1,
+            is_short=False,
+            is_change_addr=False,
+            is_subaddress=False,
+            dst_pub_view_key=state["receiver"][0].public_view_key,
+            dst_pub_spend_key=state["receiver"][0].public_spend_key,
+            _ak_amount=state["_ak_amount"][0][0],
+            commitment=bytes(32),
+            blinded_amount=state["blinded_amount"][0][0],
+            blinded_mask=state["blinded_mask"][0][0],
+            is_last=True,
+        )
+
+    @staticmethod
+    def test_close_tx_no_change(monero: MoneroCmd):
+        monero.close_tx()

--- a/tests/test_sig_real_sweep_dummy_change.py
+++ b/tests/test_sig_real_sweep_dummy_change.py
@@ -1,0 +1,241 @@
+"""Sweep-all/sweep-single transaction with Monero's dummy zero change output."""
+
+import pytest
+
+from ragger.backend.interface import BackendInterface
+from ragger.navigator import Navigator, NavInsID
+
+from monero_client.monero_cmd import MoneroCmd
+from monero_client.monero_crypto_cmd import MoneroCryptoCmd, PROTOCOL_VERSION
+from monero_client.monero_types import InsType, Keys, SigType, Type
+from monero_client.crypto.hmac import hmac_sha256
+from monero_client.utils.utils import get_nano_review_instructions
+
+
+INPUT_AMOUNT = 210_000_000_000
+FEE = 60_300_000
+OUTPUT_AMOUNT = INPUT_AMOUNT - FEE
+DUMMY_CHANGE_AMOUNT = 0
+
+
+def _validate_prehash_update_no_compare(monero: MoneroCmd,
+                                         backend: BackendInterface,
+                                         navigator: Navigator,
+                                         index: int,
+                                         is_short: bool,
+                                         is_change_addr: bool,
+                                         is_subaddress: bool,
+                                         dst_pub_view_key: bytes,
+                                         dst_pub_spend_key: bytes,
+                                         _ak_amount: bytes,
+                                         commitment: bytes,
+                                         blinded_mask: bytes,
+                                         blinded_amount: bytes,
+                                         is_last: bool,
+                                         swipe_count: int) -> None:
+    device = backend.device
+    payload = b"".join((
+        b"\x01" if is_subaddress else b"\x00",
+        b"\x01" if is_change_addr else b"\x00",
+        dst_pub_view_key,
+        dst_pub_spend_key,
+        _ak_amount,
+        hmac_sha256(_ak_amount, MoneroCryptoCmd.HMAC_KEY, Type.AMOUNT_KEY),
+        commitment,
+        blinded_mask,
+        blinded_amount,
+    ))
+
+    instructions = None
+    if device.is_nano:
+        instructions = get_nano_review_instructions(1 if is_last else 3)
+    elif is_last:
+        instructions = [NavInsID.SWIPE_CENTER_TO_LEFT] * swipe_count + [
+            NavInsID.USE_CASE_REVIEW_TAP,
+            NavInsID.USE_CASE_REVIEW_CONFIRM,
+        ]
+
+    backend.wait_for_text_on_screen("Processing")
+    with monero.transport.send_async(
+        cla=PROTOCOL_VERSION,
+        ins=InsType.INS_VALIDATE,
+        p1=2,
+        p2=index,
+        option=(0 if is_last else 0x80) | (0x02 if is_short else 0),
+        payload=payload,
+    ):
+        if instructions is not None:
+            navigator.navigate(
+                instructions,
+                screen_change_after_last_instruction=False,
+                timeout=10000,
+            )
+
+    sw, response = monero.transport.async_response()
+    assert sw == 0x9000, f"Expected SW_OK, got {hex(sw)}"
+    assert len(response) == 0
+
+
+@pytest.mark.incremental
+class TestSignatureRealSweepDummyChange:
+    """One destination and one amount=0 dummy change output."""
+
+    @staticmethod
+    @pytest.fixture(autouse=True, scope="class")
+    def state():
+        receiver = Keys(
+            public_view_key=bytes.fromhex("2e49ad29a1bfd98ab05c88713463d55212"
+                                          "0906b1be380211745695134e183ed0"),
+            public_spend_key=bytes.fromhex("392c4432e5a15aea227e6579a8da7d9f4"
+                                           "6fb78565e18e7f0b278f3f1a1468696"),
+            secret_view_key=bytes.fromhex("57fd02a94c7486722b1f9798dc0fb931d5"
+                                          "477a605a6fd6593573b438c02a890f"),
+            secret_spend_key=None,
+            addr="53zomVuwRkDgAQDY6qKUP6TeBy5JqXSJzhG4i7447yMXS7wdt4hKh6gQCTT"
+                 "a9FiYNpEjBoHZ9iTww3vL96P1hcmTQXvpFAo",
+        )
+
+        dummy_change = Keys(
+            public_view_key=bytes.fromhex("1fe0cf63fc16b40b5397c47a5227e4eb4d"
+                                          "9bc735dbd8d062340c11d35966f904"),
+            public_spend_key=bytes.fromhex("a22faef2684feb1583f69a3d2bd87e09b3"
+                                           "9f70276b69b8512876b7adc8ddfac8"),
+            secret_view_key=bytes.fromhex("b9209a473237f601d66246de732680cb62"
+                                          "d344fbf0d2bc23e195087d53a06f37"),
+            secret_spend_key=None,
+            addr="5R32BpY7seiTednbP9I7mzS7L9tyN0VmxSp1lSfkasRlgoO98XjU6gn"
+                 "HpwqtX9Md0e7SBj9IaWLZR2AZeEzz6NsXhLMdRi9",
+        )
+
+        return {
+            "receiver_number": 2,
+            "receiver": [receiver, dummy_change],
+            "is_change_addr": [False, True],
+            "is_subaddress": [False, False],
+            "amount": [OUTPUT_AMOUNT, DUMMY_CHANGE_AMOUNT],
+            "tx_pub_key": None,
+            "_tx_priv_key": None,
+            "_ak_amount": [[], []],
+            "blinded_amount": [[], []],
+            "blinded_mask": [[], []],
+            "y": [[], []],
+        }
+
+    @staticmethod
+    def test_set_sig_sweep_dummy_change(monero: MoneroCmd):
+        monero.reset_and_get_version(monero_client_version=b"0.18")
+        assert monero.set_signature_mode(sig_type=SigType.REAL) == SigType.REAL
+
+    @staticmethod
+    def test_open_tx_sweep_dummy_change(monero: MoneroCmd, state):
+        tx_pub_key, _tx_priv_key, fake_view_key, fake_spend_key = monero.open_tx()
+
+        assert fake_view_key == b"\x00" * 32
+        assert fake_spend_key == b"\xff" * 32
+
+        state["tx_pub_key"] = tx_pub_key
+        state["_tx_priv_key"] = _tx_priv_key
+
+    @staticmethod
+    def test_gen_txout_keys_sweep_dummy_change(monero: MoneroCmd, state):
+        for index in range(state["receiver_number"]):
+            _ak_amount, _ = monero.gen_txout_keys(
+                _tx_priv_key=state["_tx_priv_key"],
+                tx_pub_key=state["tx_pub_key"],
+                dst_pub_view_key=state["receiver"][index].public_view_key,
+                dst_pub_spend_key=state["receiver"][index].public_spend_key,
+                output_index=index,
+                is_change_addr=state["is_change_addr"][index],
+                is_subaddress=state["is_subaddress"][index],
+            )
+            state["_ak_amount"][index].append(_ak_amount)
+
+    @staticmethod
+    def test_prefix_hash_sweep_dummy_change(monero: MoneroCmd,
+                                            navigator: Navigator,
+                                            device,
+                                            test_name: str):
+        monero.prefix_hash_init(test_name, device, navigator=navigator,
+                                version=0, timelock=0)
+        monero.prefix_hash_update(index=1, payload=b"", is_last=True)
+
+    @staticmethod
+    def test_gen_commitment_mask_sweep_dummy_change(monero: MoneroCmd, state):
+        for index in range(state["receiver_number"]):
+            state["y"][index].append(
+                monero.gen_commitment_mask(state["_ak_amount"][index][0])
+            )
+
+    @staticmethod
+    def test_blind_sweep_dummy_change(monero: MoneroCmd, state):
+        assert OUTPUT_AMOUNT + FEE == INPUT_AMOUNT
+
+        for index in range(state["receiver_number"]):
+            blinded_mask, blinded_amount = monero.blind(
+                _ak_amount=state["_ak_amount"][index][0],
+                mask=state["y"][index][0],
+                amount=state["amount"][index],
+                is_short=True,
+            )
+
+            mask, amount = monero.unblind(
+                _ak_amount=state["_ak_amount"][index][0],
+                blinded_mask=blinded_mask,
+                blinded_amount=blinded_amount,
+                is_short=True,
+            )
+
+            assert state["y"][index][0] == mask
+            assert state["amount"][index] == int.from_bytes(amount, byteorder="little")
+
+            state["blinded_mask"][index].append(blinded_mask)
+            state["blinded_amount"][index].append(blinded_amount)
+
+    @staticmethod
+    def test_validate_sweep_dummy_change(monero: MoneroCmd,
+                                         backend: BackendInterface,
+                                         navigator: Navigator,
+                                         test_name,
+                                         state):
+        device = backend.device
+
+        monero.validate_prehash_init(test_name, device, navigator, 1, 0, FEE)
+
+        for index in range(state["receiver_number"]):
+            is_last = index == state["receiver_number"] - 1
+            _validate_prehash_update_no_compare(
+                monero,
+                backend,
+                navigator,
+                index=index + 1,
+                is_short=True,
+                is_change_addr=state["is_change_addr"][index],
+                is_subaddress=state["is_subaddress"][index],
+                dst_pub_view_key=state["receiver"][index].public_view_key,
+                dst_pub_spend_key=state["receiver"][index].public_spend_key,
+                _ak_amount=state["_ak_amount"][index][0],
+                commitment=bytes(32),
+                blinded_amount=state["blinded_amount"][index][0],
+                blinded_mask=state["blinded_mask"][index][0],
+                is_last=is_last,
+                swipe_count=3,
+            )
+
+        for index in range(state["receiver_number"]):
+            monero.validate_prehash_finalize(
+                index=index + 1,
+                is_short=False,
+                is_change_addr=state["is_change_addr"][index],
+                is_subaddress=state["is_subaddress"][index],
+                dst_pub_view_key=state["receiver"][index].public_view_key,
+                dst_pub_spend_key=state["receiver"][index].public_spend_key,
+                _ak_amount=state["_ak_amount"][index][0],
+                commitment=bytes(32),
+                blinded_amount=state["blinded_amount"][index][0],
+                blinded_mask=state["blinded_mask"][index][0],
+                is_last=index == state["receiver_number"] - 1,
+            )
+
+    @staticmethod
+    def test_close_tx_sweep_dummy_change(monero: MoneroCmd):
+        monero.close_tx()

--- a/tests/test_vuln_change_address.py
+++ b/tests/test_vuln_change_address.py
@@ -25,11 +25,13 @@ Attack path
 
 Test classes
 ------------
-  TestChangeAddressVuln   — demonstrates device ACCEPTS the attack (SW_OK).
-                            After the Option-2 fix this class will fail at
-                            test_gen_txout_keys (SecurityChangeAddress raised).
-  TestChangeAddressFixed  — demonstrates device REJECTS the attack after the
-                            fix (SecurityChangeAddress on gen_txout_keys).
+  HistoricalChangeAddressVuln
+                          — documents the pre-fix exploit path. This class is
+                            not collected by pytest.
+  TestChangeAddressFixed  — keeps gen_txout_keys accepting change outputs.
+  TestChangeAddressFixed_Prehash
+                          — demonstrates device REJECTS non-zero spoofed change
+                            after the fix.
   TestLegitimateChange    — sanity: user's own primary address IS accepted.
 
 Keys used (from seed "abandon … about"):
@@ -43,6 +45,7 @@ import pytest
 import nacl.bindings as nb
 from Crypto.Hash import keccak
 from ragger.backend.interface import BackendInterface
+from ragger.error import ExceptionRAPDU
 from ragger.navigator import Navigator, NavInsID
 
 from monero_client.monero_cmd import MoneroCmd
@@ -51,7 +54,6 @@ from monero_client.monero_types import InsType, Type, Keys, SigType
 from monero_client.crypto.hmac import hmac_sha256
 from monero_client.utils.varint import encode_varint
 from monero_client.utils.utils import get_nano_review_instructions
-from monero_client.exception import SecurityChangeAddress
 
 # ---------------------------------------------------------------------------
 # Monero Ed25519 helpers (client-side, for spending proof)
@@ -111,20 +113,22 @@ _FEE = 100_000_000_000
 
 
 # ---------------------------------------------------------------------------
-# TestChangeAddressVuln
+# HistoricalChangeAddressVuln
 # ---------------------------------------------------------------------------
-@pytest.mark.incremental
-@pytest.mark.skip(reason="Tests that showed the fixed bug")
-class TestChangeAddressVuln:
+class HistoricalChangeAddressVuln:
     """
-    Demonstrates the attack end-to-end:
+    Historical pre-fix PoC for the attack:
       1. gen_txout_keys accepts attacker's (A', B') with is_change=True → SW_OK
       2. validate (prehash_update) shows "Change: 5.9 XMR" with NO address → user
          cannot detect the substitution, approves → device signs
       3. Client-side math proves the attacker can spend the diverted output
 
     BEFORE the fix  → all steps pass (vulnerability present).
-    AFTER the fix   → test_gen_txout_keys raises SecurityChangeAddress.
+    AFTER the fix   → prehash_update raises SecurityChangeAddress.
+
+    Keep this class out of pytest collection: the active regression coverage is
+    TestChangeAddressFixed_Prehash, which asserts the 0x691C rejection without
+    trying to navigate an output UI that should no longer appear.
     """
 
     @staticmethod
@@ -259,7 +263,9 @@ class TestChangeAddressVuln:
             _ATTACKER_A_PUB,    # A' — NOT shown to user
             _ATTACKER_B_PUB,    # B' — NOT shown to user
             state["_ak_amount"][1][0],
-            hmac_sha256(state["_ak_amount"][1][0], MoneroCryptoCmd.HMAC_KEY, Type.AMOUNT_KEY),
+            hmac_sha256(state["_ak_amount"][1][0],
+                        MoneroCryptoCmd.HMAC_KEY,
+                        Type.AMOUNT_KEY),
             bytes(32),          # commitment
             state["blinded_mask"][1][0],
             state["blinded_amount"][1][0],
@@ -332,7 +338,8 @@ class TestChangeAddressVuln:
         """
         R = state["tx_pub_key"]
         P_actual = state["eph_key_change"]
-        assert P_actual is not None, "gen_txout_keys must have succeeded (vulnerability present)"
+        assert P_actual is not None, \
+            "gen_txout_keys must have succeeded (vulnerability present)"
 
         a = _USER.secret_view_key
 
@@ -369,21 +376,13 @@ class TestChangeAddressVuln:
 
 
 # ---------------------------------------------------------------------------
-# TestChangeAddressFixed  (passes only after the Option-2 fix is applied)
+# TestChangeAddressFixed
 # ---------------------------------------------------------------------------
 @pytest.mark.incremental
 class TestChangeAddressFixed:
     """
-    After the fix, gen_txout_keys rejects is_change=True outputs whose
-    (A_out, B_out) does not match the device-derived candidate set.
-
-    Candidate set built by the device:
-      • (A, B)           — user's primary address   (always included)
-      • (A_{M,0}, B_{M,0})  for each major index M seen during
-        INS_GET_SUBADDRESS_SECRET_KEY calls in this tx
-
-    The attacker's (A', B') is overwhelmingly unlikely to collide with any
-    candidate, so SW_SECURITY_CHANGE_ADDRESS (0x691C) is returned.
+    gen_txout_keys keeps accepting is_change=True outputs. The amount is only
+    known later in prehash_update.
     """
 
     @staticmethod
@@ -408,10 +407,10 @@ class TestChangeAddressFixed:
     @staticmethod
     def test_gen_txout_keys_fixed(monero: MoneroCmd, state):
         """
-        Output 0 (is_change=False, any address): accepted — check is not triggered.
-        Output 1 (is_change=True, attacker's address): rejected → SecurityChangeAddress.
+        Output 0 (is_change=False, any address): accepted.
+        Output 1 (is_change=True, attacker's address): accepted here because
+        amount-aware validation happens in prehash_update.
         """
-        # Output 0: normal destination, no change-address check
         monero.gen_txout_keys(
             _tx_priv_key=state["_tx_priv_key"],
             tx_pub_key=state["tx_pub_key"],
@@ -422,27 +421,19 @@ class TestChangeAddressFixed:
             is_subaddress=False,
         )
 
-        # Output 1: attacker address tagged as change → MUST be rejected after fix.
-        # Ragger's Speculos backend raises ExceptionRAPDU at the transport layer
-        # for any non-9000 status before monero_cmd.py can dispatch to SecurityChangeAddress.
-        from ragger.error import ExceptionRAPDU
-        with pytest.raises(ExceptionRAPDU) as exc_info:
-            monero.gen_txout_keys(
-                _tx_priv_key=state["_tx_priv_key"],
-                tx_pub_key=state["tx_pub_key"],
-                dst_pub_view_key=_ATTACKER_A_PUB,
-                dst_pub_spend_key=_ATTACKER_B_PUB,
-                output_index=1,
-                is_change_addr=True,
-                is_subaddress=False,
-            )
-        assert exc_info.value.status == 0x691C, (
-            f"Expected SW_SECURITY_CHANGE_ADDRESS (0x691C), got {hex(exc_info.value.status)}"
+        monero.gen_txout_keys(
+            _tx_priv_key=state["_tx_priv_key"],
+            tx_pub_key=state["tx_pub_key"],
+            dst_pub_view_key=_ATTACKER_A_PUB,
+            dst_pub_spend_key=_ATTACKER_B_PUB,
+            output_index=1,
+            is_change_addr=True,
+            is_subaddress=False,
         )
 
 
 # ---------------------------------------------------------------------------
-# TestChangeAddressFixed_Prehash  (passes only after the Option-2 fix is applied)
+# TestChangeAddressFixed_Prehash
 # ---------------------------------------------------------------------------
 @pytest.mark.incremental
 class TestChangeAddressFixed_Prehash:
@@ -455,8 +446,8 @@ class TestChangeAddressFixed_Prehash:
     The substitution attack is deferred to prehash_update, where the host swaps
     output 1's Aout/Bout to the attacker's keys while keeping is_change=True.
 
-    After the fix, prehash_update calls monero_check_change_address before any state
-    mutation and returns SW_SECURITY_CHANGE_ADDRESS (0x691C) without showing UI.
+    prehash_update rejects non-zero spoofed change with
+    SW_SECURITY_CHANGE_ADDRESS (0x691C).
     """
 
     @staticmethod
@@ -541,11 +532,8 @@ class TestChangeAddressFixed_Prehash:
         """
         Fee UI is shown and approved (legitimate).  Immediately after, the very
         first prehash_update carries attacker's (A', B') with is_change=True.
-        monero_check_change_address fires before any state mutation or output UI
-        and returns SW_SECURITY_CHANGE_ADDRESS (0x691C) on both Nano and Flex.
-
-        No intermediate legitimate output is processed: the check rejects
-        regardless of position because it runs before any state mutation.
+        monero_check_change_address returns SW_SECURITY_CHANGE_ADDRESS (0x691C)
+        without showing output UI.
         """
         device = backend.device
 
@@ -560,7 +548,9 @@ class TestChangeAddressFixed_Prehash:
             _ATTACKER_A_PUB,            # A' — not in device's candidate set
             _ATTACKER_B_PUB,            # B' — not in device's candidate set
             state["_ak_amount"][1],     # AKout with valid HMAC
-            hmac_sha256(state["_ak_amount"][1], MoneroCryptoCmd.HMAC_KEY, Type.AMOUNT_KEY),
+            hmac_sha256(state["_ak_amount"][1],
+                        MoneroCryptoCmd.HMAC_KEY,
+                        Type.AMOUNT_KEY),
             bytes(32),                  # commitment — check never reached
             state["blinded_mask"][1],
             state["blinded_amount"][1],
@@ -575,11 +565,227 @@ class TestChangeAddressFixed_Prehash:
             payload=payload,
         )
 
-        from ragger.error import ExceptionRAPDU
         with pytest.raises(ExceptionRAPDU) as exc_info:
             monero.transport.recv()
         assert exc_info.value.status == 0x691C, (
-            f"Expected SW_SECURITY_CHANGE_ADDRESS (0x691C), got {hex(exc_info.value.status)}"
+            f"Expected SW_SECURITY_CHANGE_ADDRESS (0x691C), got "
+            f"{hex(exc_info.value.status)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestShortAmountCanonical_Prehash
+# ---------------------------------------------------------------------------
+@pytest.mark.incremental
+class TestShortAmountCanonical_Prehash:
+    """Reject short amounts with non-zero bytes above the displayed uint64."""
+
+    @staticmethod
+    @pytest.fixture(autouse=True, scope="class")
+    def state():
+        return {
+            "tx_pub_key": None,
+            "_tx_priv_key": None,
+            "_ak_amount": None,
+            "y": None,
+            "blinded_mask": None,
+            "blinded_amount": None,
+        }
+
+    @staticmethod
+    def test_reset_short_amount(monero: MoneroCmd):
+        monero.reset_and_get_version(monero_client_version=b"0.18")
+
+    @staticmethod
+    def test_set_sig_short_amount(monero: MoneroCmd):
+        assert monero.set_signature_mode(sig_type=SigType.REAL) == SigType.REAL
+
+    @staticmethod
+    def test_open_tx_short_amount(monero: MoneroCmd, state):
+        tx_pub_key, _tx_priv_key, _, _ = monero.open_tx()
+        state["tx_pub_key"] = tx_pub_key
+        state["_tx_priv_key"] = _tx_priv_key
+
+    @staticmethod
+    def test_gen_txout_keys_short_amount(monero: MoneroCmd, state):
+        _ak, _ = monero.gen_txout_keys(
+            _tx_priv_key=state["_tx_priv_key"],
+            tx_pub_key=state["tx_pub_key"],
+            dst_pub_view_key=_USER.public_view_key,
+            dst_pub_spend_key=_USER.public_spend_key,
+            output_index=0,
+            is_change_addr=True,
+            is_subaddress=False,
+        )
+        state["_ak_amount"] = _ak
+
+    @staticmethod
+    def test_prefix_hash_short_amount(monero: MoneroCmd, device, test_name: str):
+        monero.prefix_hash_init(test_name, device,
+                                navigator=None, version=0, timelock=0)
+        monero.prefix_hash_update(index=1, payload=b"", is_last=True)
+
+    @staticmethod
+    def test_blind_short_amount(monero: MoneroCmd, state):
+        state["y"] = monero.gen_commitment_mask(state["_ak_amount"])
+        bm, ba = monero.blind(
+            _ak_amount=state["_ak_amount"],
+            mask=state["y"],
+            amount=0,
+            is_short=True,
+        )
+        ba = bytearray(ba)
+        ba[8] = 1
+        state["blinded_mask"] = bm
+        state["blinded_amount"] = bytes(ba)
+
+    @staticmethod
+    def test_prehash_update_short_amount_rejected(
+        monero: MoneroCmd,
+        backend: BackendInterface,
+        navigator: Navigator,
+        test_name: str,
+        state,
+    ):
+        device = backend.device
+
+        monero.validate_prehash_init(test_name, device, navigator, 1, 0, _FEE)
+
+        payload = b"".join((
+            b"\x00",
+            b"\x01",
+            _ATTACKER_A_PUB,
+            _ATTACKER_B_PUB,
+            state["_ak_amount"],
+            hmac_sha256(state["_ak_amount"],
+                        MoneroCryptoCmd.HMAC_KEY,
+                        Type.AMOUNT_KEY),
+            bytes(32),
+            state["blinded_mask"],
+            state["blinded_amount"],
+        ))
+
+        monero.transport.send(
+            cla=PROTOCOL_VERSION,
+            ins=InsType.INS_VALIDATE,
+            p1=2,
+            p2=1,
+            option=0x02,
+            payload=payload,
+        )
+
+        with pytest.raises(ExceptionRAPDU) as exc_info:
+            monero.transport.recv()
+        assert exc_info.value.status == 0x6913, (
+            f"Expected SW_SECURITY_AMOUNT_CHAIN_CONTROL (0x6913), got "
+            f"{hex(exc_info.value.status)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestFullAmountZeroLow64_Prehash
+# ---------------------------------------------------------------------------
+@pytest.mark.incremental
+class TestFullAmountZeroLow64_Prehash:
+    """Do not treat non-short amounts with low64=0 as dummy change."""
+
+    @staticmethod
+    @pytest.fixture(autouse=True, scope="class")
+    def state():
+        return {
+            "tx_pub_key": None,
+            "_tx_priv_key": None,
+            "_ak_amount": None,
+            "y": None,
+            "blinded_mask": None,
+            "blinded_amount": None,
+        }
+
+    @staticmethod
+    def test_reset_full_amount(monero: MoneroCmd):
+        monero.reset_and_get_version(monero_client_version=b"0.18")
+
+    @staticmethod
+    def test_set_sig_full_amount(monero: MoneroCmd):
+        assert monero.set_signature_mode(sig_type=SigType.REAL) == SigType.REAL
+
+    @staticmethod
+    def test_open_tx_full_amount(monero: MoneroCmd, state):
+        tx_pub_key, _tx_priv_key, _, _ = monero.open_tx()
+        state["tx_pub_key"] = tx_pub_key
+        state["_tx_priv_key"] = _tx_priv_key
+
+    @staticmethod
+    def test_gen_txout_keys_full_amount(monero: MoneroCmd, state):
+        _ak, _ = monero.gen_txout_keys(
+            _tx_priv_key=state["_tx_priv_key"],
+            tx_pub_key=state["tx_pub_key"],
+            dst_pub_view_key=_USER.public_view_key,
+            dst_pub_spend_key=_USER.public_spend_key,
+            output_index=0,
+            is_change_addr=True,
+            is_subaddress=False,
+        )
+        state["_ak_amount"] = _ak
+
+    @staticmethod
+    def test_prefix_hash_full_amount(monero: MoneroCmd, device, test_name: str):
+        monero.prefix_hash_init(test_name, device,
+                                navigator=None, version=0, timelock=0)
+        monero.prefix_hash_update(index=1, payload=b"", is_last=True)
+
+    @staticmethod
+    def test_blind_full_amount(monero: MoneroCmd, state):
+        state["y"] = monero.gen_commitment_mask(state["_ak_amount"])
+        bm, ba = monero.blind(
+            _ak_amount=state["_ak_amount"],
+            mask=state["y"],
+            amount=1 << 64,
+            is_short=False,
+        )
+        state["blinded_mask"] = bm
+        state["blinded_amount"] = ba
+
+    @staticmethod
+    def test_prehash_update_full_amount_rejected(
+        monero: MoneroCmd,
+        backend: BackendInterface,
+        navigator: Navigator,
+        test_name: str,
+        state,
+    ):
+        device = backend.device
+
+        monero.validate_prehash_init(test_name, device, navigator, 1, 0, _FEE)
+
+        payload = b"".join((
+            b"\x00",
+            b"\x01",
+            _ATTACKER_A_PUB,
+            _ATTACKER_B_PUB,
+            state["_ak_amount"],
+            hmac_sha256(state["_ak_amount"],
+                        MoneroCryptoCmd.HMAC_KEY,
+                        Type.AMOUNT_KEY),
+            bytes(32),
+            state["blinded_mask"],
+            state["blinded_amount"],
+        ))
+
+        monero.transport.send(
+            cla=PROTOCOL_VERSION,
+            ins=InsType.INS_VALIDATE,
+            p1=2,
+            p2=1,
+            option=0,
+            payload=payload,
+        )
+
+        with pytest.raises(ExceptionRAPDU) as exc_info:
+            monero.transport.recv()
+        assert exc_info.value.status == 0x691C, (
+            f"Expected SW_SECURITY_CHANGE_ADDRESS (0x691C), got "
+            f"{hex(exc_info.value.status)}"
         )
 
 
@@ -657,7 +863,10 @@ def _compute_subaddress_keys(major: int, minor: int):
     return C, D  # (view_pub, spend_pub)
 
 
-def _record_index(monero: MoneroCmd, fake_view_key: bytes, major: int, minor: int) -> None:
+def _record_index(monero: MoneroCmd,
+                  fake_view_key: bytes,
+                  major: int,
+                  minor: int) -> None:
     """
     Send INS_GET_SUBADDRESS_SECRET_KEY with the given (major, minor) index so
     the device records it in tx_change_major/minor_indices.  Return value is
@@ -678,7 +887,7 @@ def _record_index(monero: MoneroCmd, fake_view_key: bytes, major: int, minor: in
         payload=payload,
     )
     sw, _ = monero.transport.recv()
-    assert sw & 0x9000, f"INS_GET_SUBADDRESS_SECRET_KEY failed with {hex(sw)}"
+    assert sw == 0x9000, f"INS_GET_SUBADDRESS_SECRET_KEY failed with {hex(sw)}"
 
 
 # ---------------------------------------------------------------------------
@@ -695,7 +904,16 @@ class TestSubaddressChangeDirect:
     @staticmethod
     @pytest.fixture(autouse=True, scope="class")
     def state():
-        return {"tx_pub_key": None, "_tx_priv_key": None, "fvk": None}
+        return {
+            "tx_pub_key": None,
+            "_tx_priv_key": None,
+            "fvk": None,
+            "_ak_amount": None,
+            "y": None,
+            "blinded_mask": None,
+            "blinded_amount": None,
+            "address": None,
+        }
 
     @staticmethod
     def test_reset_sub_direct(monero: MoneroCmd):
@@ -713,16 +931,17 @@ class TestSubaddressChangeDirect:
         state["fvk"] = fvk
 
     @staticmethod
-    def test_subaddr_direct_accepted(monero: MoneroCmd, state):
+    def test_subaddr_direct_gen_txout_keys(monero: MoneroCmd, state):
         """
-        Record index (1, 3) via INS_GET_SUBADDRESS_SECRET_KEY, then verify
-        that gen_txout_keys with is_change=True and (A_{1,3}, B_{1,3}) succeeds.
+        Record index (1, 3), then verify gen_txout_keys still accepts the
+        matching subaddress. The real change check happens in prehash_update.
         """
         _record_index(monero, state["fvk"], major=1, minor=3)
         A_sub, B_sub = _compute_subaddress_keys(major=1, minor=3)
+        state["address"] = (A_sub, B_sub)
 
-        # Must not raise — the exact subaddress is in the whitelist.
-        monero.gen_txout_keys(
+        # Must not raise -- amount-aware validation happens later.
+        _ak, _ = monero.gen_txout_keys(
             _tx_priv_key=state["_tx_priv_key"],
             tx_pub_key=state["tx_pub_key"],
             dst_pub_view_key=A_sub,
@@ -730,6 +949,56 @@ class TestSubaddressChangeDirect:
             output_index=0,
             is_change_addr=True,
             is_subaddress=True,
+        )
+        state["_ak_amount"] = _ak
+
+    @staticmethod
+    def test_prefix_hash_sub_direct(monero: MoneroCmd, device, test_name: str):
+        monero.prefix_hash_init(test_name, device,
+                                navigator=None, version=0, timelock=0)
+        monero.prefix_hash_update(index=1, payload=b"", is_last=True)
+
+    @staticmethod
+    def test_blind_sub_direct(monero: MoneroCmd, state):
+        state["y"] = monero.gen_commitment_mask(state["_ak_amount"])
+        bm, ba = monero.blind(
+            _ak_amount=state["_ak_amount"],
+            mask=state["y"],
+            amount=_AMOUNT_CHANGE,
+            is_short=True,
+        )
+        state["blinded_mask"] = bm
+        state["blinded_amount"] = ba
+
+    @staticmethod
+    def test_prehash_update_sub_direct_accepted(
+        monero: MoneroCmd,
+        backend: BackendInterface,
+        navigator: Navigator,
+        test_name: str,
+        state,
+    ):
+        """The exact recorded subaddress must pass the real change check."""
+        device = backend.device
+        A_sub, B_sub = state["address"]
+
+        monero.validate_prehash_init(test_name, device, navigator, 1, 0, _FEE)
+        monero.validate_prehash_update(
+            backend,
+            test_name,
+            navigator,
+            index=1,
+            is_short=True,
+            is_change_addr=True,
+            is_subaddress=True,
+            dst_pub_view_key=A_sub,
+            dst_pub_spend_key=B_sub,
+            _ak_amount=state["_ak_amount"],
+            commitment=bytes(32),
+            blinded_amount=state["blinded_amount"],
+            blinded_mask=state["blinded_mask"],
+            is_last=False,
+            do_navigation=False,
         )
 
 
@@ -747,7 +1016,16 @@ class TestSubaddressChangeAccountRoot:
     @staticmethod
     @pytest.fixture(autouse=True, scope="class")
     def state():
-        return {"tx_pub_key": None, "_tx_priv_key": None, "fvk": None}
+        return {
+            "tx_pub_key": None,
+            "_tx_priv_key": None,
+            "fvk": None,
+            "_ak_amount": None,
+            "y": None,
+            "blinded_mask": None,
+            "blinded_amount": None,
+            "address": None,
+        }
 
     @staticmethod
     def test_reset_sub_root(monero: MoneroCmd):
@@ -765,17 +1043,18 @@ class TestSubaddressChangeAccountRoot:
         state["fvk"] = fvk
 
     @staticmethod
-    def test_account_root_accepted(monero: MoneroCmd, state):
+    def test_account_root_gen_txout_keys(monero: MoneroCmd, state):
         """
         Record index (1, 3) — only the input subaddress, not the root.
-        Then verify that gen_txout_keys with is_change=True and the account
-        root (A_{1,0}, B_{1,0}) succeeds (standard wallet change routing).
+        Then verify gen_txout_keys accepts the account root (A_{1,0}, B_{1,0});
+        standard wallet change routing is really checked in prehash_update.
         """
         _record_index(monero, state["fvk"], major=1, minor=3)
         A_root, B_root = _compute_subaddress_keys(major=1, minor=0)
+        state["address"] = (A_root, B_root)
 
         # Must not raise — account root of a seen major is always whitelisted.
-        monero.gen_txout_keys(
+        _ak, _ = monero.gen_txout_keys(
             _tx_priv_key=state["_tx_priv_key"],
             tx_pub_key=state["tx_pub_key"],
             dst_pub_view_key=A_root,
@@ -783,4 +1062,54 @@ class TestSubaddressChangeAccountRoot:
             output_index=0,
             is_change_addr=True,
             is_subaddress=True,
+        )
+        state["_ak_amount"] = _ak
+
+    @staticmethod
+    def test_prefix_hash_sub_root(monero: MoneroCmd, device, test_name: str):
+        monero.prefix_hash_init(test_name, device,
+                                navigator=None, version=0, timelock=0)
+        monero.prefix_hash_update(index=1, payload=b"", is_last=True)
+
+    @staticmethod
+    def test_blind_sub_root(monero: MoneroCmd, state):
+        state["y"] = monero.gen_commitment_mask(state["_ak_amount"])
+        bm, ba = monero.blind(
+            _ak_amount=state["_ak_amount"],
+            mask=state["y"],
+            amount=_AMOUNT_CHANGE,
+            is_short=True,
+        )
+        state["blinded_mask"] = bm
+        state["blinded_amount"] = ba
+
+    @staticmethod
+    def test_prehash_update_sub_root_accepted(
+        monero: MoneroCmd,
+        backend: BackendInterface,
+        navigator: Navigator,
+        test_name: str,
+        state,
+    ):
+        """The account root of a recorded major must pass the real change check."""
+        device = backend.device
+        A_root, B_root = state["address"]
+
+        monero.validate_prehash_init(test_name, device, navigator, 1, 0, _FEE)
+        monero.validate_prehash_update(
+            backend,
+            test_name,
+            navigator,
+            index=1,
+            is_short=True,
+            is_change_addr=True,
+            is_subaddress=True,
+            dst_pub_view_key=A_root,
+            dst_pub_spend_key=B_root,
+            _ak_amount=state["_ak_amount"],
+            commitment=bytes(32),
+            blinded_amount=state["blinded_amount"],
+            blinded_mask=state["blinded_mask"],
+            is_last=False,
+            do_navigation=False,
         )


### PR DESCRIPTION
# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [x] App update process has been followed <!-- See comment below -->
- [x] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->

<!-- Make sure you followed the process described in https://developers.ledger.com/docs/device-app/deliver/maintenance before opening your Pull Request.
Don't hesitate to contact us directly on Discord if you have any questions ! https://developers.ledger.com/discord -->


## Summary

This moves change-address validation from `GEN_TXOUT_KEYS` to `INS_VALIDATE`,
after the output amount has been unblinded.

The previous check happened before the device knew the output amount, so it
could not distinguish a real change output from the zero-amount dummy change
output that Monero may include in `sweep_all` / `sweep_single` transactions.

With this change:
- non-zero change outputs still have to match the wallet primary address or an
  accepted subaddress change candidate
- zero-amount dummy change outputs are accepted only when the full decrypted
  amount is canonically zero
- short amount encodings with non-zero high bytes are rejected

## Security

Spoofed non-zero change outputs are rejected during `prehash_update`, before
signing and before updating the transaction hash state.

The existing commitment and OUTK checks remain in place. This also avoids using
`G_monero_vstate.mlsagH` as temporary storage while encoding addresses, which
could corrupt the signing prehash on Stax/Flex flows.

## Tests

- Added regression coverage for spoofed non-zero change outputs
- Added coverage for canonical short amounts and low64-zero non-short amounts
- Added sweep/no-change signing tests
- Extended subaddress change tests through `prehash_update`

Tested with Speculos on Stax and with a physical Ledger Stax debug build on
stagenet.